### PR TITLE
[Feat] 전역 예외처리 관련 클래스 추가, 공지사항 crud 기능 추가

### DIFF
--- a/src/main/java/com/example/tenpaws/domain/board/controller/AnnouncementController.java
+++ b/src/main/java/com/example/tenpaws/domain/board/controller/AnnouncementController.java
@@ -1,0 +1,69 @@
+package com.example.tenpaws.domain.board.controller;
+
+import com.example.tenpaws.domain.board.dto.request.CreateAnnouncementRequest;
+import com.example.tenpaws.domain.board.dto.request.UpdateAnnouncementRequest;
+import com.example.tenpaws.domain.board.dto.response.AnnouncementListViewResponse;
+import com.example.tenpaws.domain.board.dto.response.AnnouncementResponse;
+import com.example.tenpaws.domain.board.entity.Announcement;
+import com.example.tenpaws.domain.board.service.AnnouncementService;
+import com.example.tenpaws.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/announcements")
+@RequiredArgsConstructor
+public class AnnouncementController {
+
+    private final AnnouncementService announcementService;
+
+    // Create
+    @PostMapping
+    public ResponseEntity<ApiResponse<Announcement>> createAnnouncement(@RequestBody CreateAnnouncementRequest request) {
+        Announcement savedAnnouncement = announcementService.save(request);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(savedAnnouncement));
+    }
+
+    // Read(Page)
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<AnnouncementListViewResponse>>> getAnnouncementList(
+            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(ApiResponse.success(announcementService.getList(pageable)));
+    }
+
+    // Read(By id)
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<AnnouncementResponse>> findAnnouncementById(@PathVariable long id) {
+        Announcement announcement = announcementService.findById(id);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(new AnnouncementResponse(announcement)));
+    }
+
+    // Update
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<Announcement>> updateAnnouncement(
+            @PathVariable long id,
+            @RequestBody UpdateAnnouncementRequest request) {
+        Announcement updatedAnnouncement = announcementService.update(id, request);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(updatedAnnouncement));
+    }
+
+    // Delete
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteAnnouncement(@PathVariable long id) {
+        announcementService.delete(id);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "Announcement successfully deleted"));
+    }
+}

--- a/src/main/java/com/example/tenpaws/domain/board/dto/request/CreateAnnouncementRequest.java
+++ b/src/main/java/com/example/tenpaws/domain/board/dto/request/CreateAnnouncementRequest.java
@@ -1,0 +1,22 @@
+package com.example.tenpaws.domain.board.dto.request;
+
+import com.example.tenpaws.domain.board.entity.Announcement;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CreateAnnouncementRequest {
+
+    private String title;
+    private String content;
+
+    public Announcement toEntity() {
+        return Announcement.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/example/tenpaws/domain/board/dto/request/UpdateAnnouncementRequest.java
+++ b/src/main/java/com/example/tenpaws/domain/board/dto/request/UpdateAnnouncementRequest.java
@@ -1,0 +1,13 @@
+package com.example.tenpaws.domain.board.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UpdateAnnouncementRequest {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/example/tenpaws/domain/board/dto/response/AnnouncementListViewResponse.java
+++ b/src/main/java/com/example/tenpaws/domain/board/dto/response/AnnouncementListViewResponse.java
@@ -1,0 +1,16 @@
+package com.example.tenpaws.domain.board.dto.response;
+
+import com.example.tenpaws.domain.board.entity.Announcement;
+import lombok.Getter;
+
+@Getter
+public class AnnouncementListViewResponse {
+
+    private final Long id;
+    private final String title;
+
+    public AnnouncementListViewResponse(Announcement announcement) {
+        this.id = announcement.getId();
+        this.title = announcement.getTitle();
+    }
+}

--- a/src/main/java/com/example/tenpaws/domain/board/dto/response/AnnouncementResponse.java
+++ b/src/main/java/com/example/tenpaws/domain/board/dto/response/AnnouncementResponse.java
@@ -1,0 +1,19 @@
+package com.example.tenpaws.domain.board.dto.response;
+
+
+import com.example.tenpaws.domain.board.entity.Announcement;
+import lombok.Getter;
+
+@Getter
+public class AnnouncementResponse {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+
+    public AnnouncementResponse(Announcement announcement) {
+        this.id = announcement.getId();
+        this.title = announcement.getTitle();
+        this.content = announcement.getContent();
+    }
+}

--- a/src/main/java/com/example/tenpaws/domain/board/repository/AnnouncementRepository.java
+++ b/src/main/java/com/example/tenpaws/domain/board/repository/AnnouncementRepository.java
@@ -1,0 +1,7 @@
+package com.example.tenpaws.domain.board.repository;
+
+import com.example.tenpaws.domain.board.entity.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+}

--- a/src/main/java/com/example/tenpaws/domain/board/service/AnnouncementService.java
+++ b/src/main/java/com/example/tenpaws/domain/board/service/AnnouncementService.java
@@ -1,0 +1,50 @@
+package com.example.tenpaws.domain.board.service;
+
+import com.example.tenpaws.domain.board.dto.request.CreateAnnouncementRequest;
+import com.example.tenpaws.domain.board.dto.request.UpdateAnnouncementRequest;
+import com.example.tenpaws.domain.board.dto.response.AnnouncementListViewResponse;
+import com.example.tenpaws.domain.board.entity.Announcement;
+import com.example.tenpaws.domain.board.repository.AnnouncementRepository;
+import com.example.tenpaws.global.exception.BaseException;
+import com.example.tenpaws.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementService {
+
+    private final AnnouncementRepository announcementRepository;
+
+    public Announcement save(CreateAnnouncementRequest request) {
+        return announcementRepository.save(request.toEntity());
+    }
+
+    public Page<AnnouncementListViewResponse> getList(Pageable pageable) {
+        return announcementRepository.findAll(pageable)
+                .map(AnnouncementListViewResponse::new);
+    }
+
+    public Announcement findById(long id) {
+        return announcementRepository.findById(id)
+                .orElseThrow(() -> new BaseException(ErrorCode.ANNOUNCEMENT_NOT_FOUND));
+    }
+
+    @Transactional
+    public Announcement update(long id, UpdateAnnouncementRequest request) {
+        Announcement announcement = announcementRepository.findById(id)
+                .orElseThrow(() -> new BaseException(ErrorCode.ANNOUNCEMENT_NOT_FOUND));
+
+        announcement.update(request.getTitle(), request.getContent());
+        return announcement;
+    }
+
+    public void delete(long id) {
+        announcementRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/example/tenpaws/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/tenpaws/global/advice/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.tenpaws.global.advice;
+
+import com.example.tenpaws.global.api.ApiResponse;
+import com.example.tenpaws.global.exception.BaseException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("Internal server error"));
+    }
+}

--- a/src/main/java/com/example/tenpaws/global/api/ApiResponse.java
+++ b/src/main/java/com/example/tenpaws/global/api/ApiResponse.java
@@ -1,0 +1,24 @@
+package com.example.tenpaws.global.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private final T data;
+    private final String message;
+    private final boolean success;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(data, null, true);
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return new ApiResponse<>(data, message, true);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(null, message, false);
+    }
+}

--- a/src/main/java/com/example/tenpaws/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/tenpaws/global/config/JacksonConfig.java
@@ -1,0 +1,12 @@
+package com.example.tenpaws.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+// PageImpl 클래스 직렬화
+@Configuration
+@EnableSpringDataWebSupport(
+        pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO
+)
+public class JacksonConfig {
+}

--- a/src/main/java/com/example/tenpaws/global/exception/BaseException.java
+++ b/src/main/java/com/example/tenpaws/global/exception/BaseException.java
@@ -1,0 +1,14 @@
+package com.example.tenpaws.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/tenpaws/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/tenpaws/global/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.tenpaws.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // User
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "Email already exists"),
+    PHONE_ALREADY_EXISTS(HttpStatus.CONFLICT, "Phone already exists"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "Access denied"),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "Invalid input"),
+
+    // Announcement
+    ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Announcement not found");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#14 [Feat] 전역 예외처리 관련 클래스 추가, 공지사항 crud 기능 추가
## 🪐 작업 내용
- 전역 예외처리 관련 클래스 추가
- 공지사항 crud 기능 추가
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요? -> API 엔드포인트 테스트 완료
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## ✅ PR 포인트 & 궁금한 점
- 모든 api 엔드포인트에 대해 수동 테스트 완료하였습니다.
- 회원 기능 없이 기능 사용 가능하며, 회원 기능 추가되면 그에 맞춰서 코드를 점진적으로 개선할 예정입니다.
- ⚠ 전역 예외 처리 코드를 하나로 통합하고, 해당 클래스 내에서 예외코드를 도메인 별로 구분합니다.
- BaseException 커스텀 예외 클래스에서 처리되지 않는 예외는 GlobalExceptionHandler 전역 예외 처리기에서 처리합니다.
- 오류, 수정, 개선 사항이 있다면 말씀해주세요.

close #14 