### PR TITLE
[Feat] 사용자 로그아웃 기능 구현 + email 형식으로 로그인 기능 변경

### DIFF
--- a/src/main/java/com/example/tenpaws/domain/user/dto/UserJoinDTO.java
+++ b/src/main/java/com/example/tenpaws/domain/user/dto/UserJoinDTO.java
@@ -16,20 +16,16 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class UserJoinDTO {
 
-    @NotBlank(message = "사용자 아이디는 필수입니다")
-    @Size(min = 7, max = 20, message = "사용자 아이디는 7글자 이상, 20글자 이하로 제한됩니다")
-    private String username;
-
-    @NotBlank(message = "사용자 비밀번호는 필수입니다")
-    @Size(min = 7, max = 20, message = "사용자 아이디는 7글자 이상, 20글자 이하로 제한됩니다")
-    private String password;
-
     @NotBlank(message = "이메일 정보는 필수입니다")
     @Pattern(
             regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
             message = "유효하지 않은 이메일 형식입니다"
     )
     private String email;
+
+    @NotBlank(message = "사용자 비밀번호는 필수입니다")
+    @Size(min = 7, max = 20, message = "사용자 아이디는 7글자 이상, 20글자 이하로 제한됩니다")
+    private String password;
 
     @NotNull(message = "생년월일 정보는 필수입니다")
     @Past(message = "생년월일은 과거의 날짜여야 합니다")
@@ -50,9 +46,8 @@ public class UserJoinDTO {
     // DTO -> Entity 변환 메서드
     public User toEntity() {
         return User.builder()
-                .username(this.username)
-                .password(this.password)
                 .email(this.email)
+                .password(this.password)
                 .birthDate(this.birthDate)
                 .phoneNumber(this.phoneNumber)
                 .address(this.address)

--- a/src/main/java/com/example/tenpaws/domain/user/dto/UserJoinDTO.java
+++ b/src/main/java/com/example/tenpaws/domain/user/dto/UserJoinDTO.java
@@ -24,7 +24,7 @@ public class UserJoinDTO {
     private String email;
 
     @NotBlank(message = "사용자 비밀번호는 필수입니다")
-    @Size(min = 7, max = 20, message = "사용자 아이디는 7글자 이상, 20글자 이하로 제한됩니다")
+    @Size(min = 7, max = 20, message = "사용자 비밀번호는 7글자 이상, 20글자 이하로 제한됩니다")
     private String password;
 
     @NotNull(message = "생년월일 정보는 필수입니다")

--- a/src/main/java/com/example/tenpaws/domain/user/entity/User.java
+++ b/src/main/java/com/example/tenpaws/domain/user/entity/User.java
@@ -19,13 +19,10 @@ public class User {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String username;
+    private String email;
 
     @Column(nullable = false)
     private String password;
-
-    @Column(nullable = false, unique = true)
-    private String email;
 
     @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
@@ -49,6 +46,6 @@ public class User {
     public void changePassword(String password) {
         this.password = password;
     }
-    public void changeUsername(String username) { this.username = username; }
+    public void changeEmail(String email) { this.email = email; }
     public void changeUserRole(UserRole userRole) { this.userRole = userRole; }
 }

--- a/src/main/java/com/example/tenpaws/domain/user/repositoty/UserRepository.java
+++ b/src/main/java/com/example/tenpaws/domain/user/repositoty/UserRepository.java
@@ -3,8 +3,9 @@ package com.example.tenpaws.domain.user.repositoty;
 import com.example.tenpaws.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
-    boolean existsByUsername(String username);
     boolean existsByEmail(String email);
-    User findByUsername(String username);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/tenpaws/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/tenpaws/domain/user/service/UserServiceImpl.java
@@ -19,7 +19,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public void registerUser(UserJoinDTO userJoinDTO) {
 
-        if (userRepository.existsByUsername(userJoinDTO.getUsername())) {
+        if (userRepository.existsByEmail(userJoinDTO.getEmail())) {
             throw new IllegalArgumentException("이미 존재하는 사용자 입니다");
         }
 

--- a/src/main/java/com/example/tenpaws/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/tenpaws/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.tenpaws.global.config;
 import com.example.tenpaws.global.security.jwt.JwtFilter;
 import com.example.tenpaws.global.security.jwt.JwtUtil;
 import com.example.tenpaws.global.security.jwt.LoginFilter;
+import com.example.tenpaws.global.security.jwt.CustomLogoutFilter;
 import com.example.tenpaws.global.security.repository.RefreshRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -87,6 +89,9 @@ public class SecurityConfig {
 
         httpSecurity
                 .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
+
+        httpSecurity
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/example/tenpaws/global/security/dto/NormalUserDetails.java
+++ b/src/main/java/com/example/tenpaws/global/security/dto/NormalUserDetails.java
@@ -36,7 +36,7 @@ public class NormalUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getUsername();
+        return user.getEmail();
     }
 
     @Override

--- a/src/main/java/com/example/tenpaws/global/security/entity/RefreshEntity.java
+++ b/src/main/java/com/example/tenpaws/global/security/entity/RefreshEntity.java
@@ -16,7 +16,7 @@ public class RefreshEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String username;
+    private String email;
     private String refresh;
     private String expiration;
 }

--- a/src/main/java/com/example/tenpaws/global/security/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/tenpaws/global/security/jwt/CustomLogoutFilter.java
@@ -1,0 +1,97 @@
+package com.example.tenpaws.global.security.jwt;
+
+import com.example.tenpaws.global.security.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        // logout 주소인 지 확인
+        String requestUri = request.getRequestURI();
+        if (!requestUri.equals("/logout")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // post 방식으로 들어온 http request인 지 확인
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Refresh 토큰 쿠키 추출
+        String refreshToken = getRefreshTokenFromCookies(request);
+        if (refreshToken == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // Refresh 토큰 만료 여부 확인
+        try {
+            jwtUtil.isExpired(refreshToken);
+        } catch (ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // Refresh 토큰인지 확인
+        String category = jwtUtil.getCategory(refreshToken);
+        if (!category.equals("refresh")) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // DB에서 Refresh 토큰 존재 여부 확인
+        boolean isExist = refreshRepository.existsByRefresh(refreshToken);
+        if (!isExist) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 로그아웃 진행: Refresh 토큰 DB에서 삭제
+        refreshRepository.deleteByRefresh(refreshToken);
+
+        // Refresh 토큰 쿠키 값 삭제
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    // 쿠키에서 Refresh 토큰 추출
+    private String getRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/tenpaws/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/example/tenpaws/global/security/jwt/JwtFilter.java
@@ -41,22 +41,22 @@ public class JwtFilter extends OncePerRequestFilter {
         try {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
-            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "Access token expired");
+            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "만료된 엑세스 토큰 입니다");
             return;
         }
 
         String category = jwtUtil.getCategory(accessToken);
 
         if (!category.equals("access")) {
-            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "Invalid access token");
+            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 엑세스 토큰 입니다");
             return;
         }
 
-        String username = jwtUtil.getUsername(accessToken);
+        String email = jwtUtil.getEmail(accessToken);
         UserRole role = jwtUtil.getRole(accessToken);
 
         User user = new User();
-        user.changeUsername(username);
+        user.changeEmail(email);
         user.changeUserRole(role);
         NormalUserDetails normalUserDetails = new NormalUserDetails(user);
 

--- a/src/main/java/com/example/tenpaws/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/tenpaws/global/security/jwt/JwtUtil.java
@@ -18,8 +18,8 @@ public class JwtUtil {
         this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String getUsername(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    public String getEmail(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
     }
 
     public UserRole getRole(String token) {
@@ -35,11 +35,11 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
     }
 
-    public String createJwt(String category, String username, UserRole role, Long expiredMs) {
+    public String createJwt(String category, String email, UserRole role, Long expiredMs) {
 
         return Jwts.builder()
                 .claim("category", category)
-                .claim("username", username)
+                .claim("email", email)
                 .claim("role", role.name())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))

--- a/src/main/java/com/example/tenpaws/global/security/repository/RefreshRepository.java
+++ b/src/main/java/com/example/tenpaws/global/security/repository/RefreshRepository.java
@@ -4,12 +4,18 @@ import com.example.tenpaws.global.security.entity.RefreshEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
-    RefreshEntity findByUsername(String username);
+    RefreshEntity findByEmail(String email);
 
     @Query("SELECT r FROM RefreshEntity r WHERE r.expiration < :now")
     List<RefreshEntity> findExpiredTokens(@Param("now") String now);
+
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
 }

--- a/src/main/java/com/example/tenpaws/global/security/service/NormalUserDetailsService.java
+++ b/src/main/java/com/example/tenpaws/global/security/service/NormalUserDetailsService.java
@@ -16,13 +16,10 @@ public class NormalUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username);
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
-        if (user != null) {
-            return new NormalUserDetails(user);
-        }
-
-        return null;
+        return new NormalUserDetails(user);
     }
 }

--- a/src/test/java/com/example/tenpaws/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/example/tenpaws/domain/user/service/UserServiceImplTest.java
@@ -34,9 +34,8 @@ class UserServiceImplTest {
     @BeforeEach
     void setUp() {
         userJoinDTO = new UserJoinDTO(
-                "username123",
-                "password123",
                 "user@example.com",
+                "password123",
                 LocalDate.of(1990, 1, 1),
                 "010-1234-5678",
                 "123 Street",
@@ -48,7 +47,7 @@ class UserServiceImplTest {
 
     @Test
     void 적절한_회원가입_절차() {
-        when(userRepository.existsByUsername(userJoinDTO.getUsername())).thenReturn(false);
+        when(userRepository.existsByEmail(userJoinDTO.getEmail())).thenReturn(false);
 
         // Given: BCryptPasswordEncoder가 비밀번호를 암호화하도록 설정
         when(bCryptPasswordEncoder.encode(userJoinDTO.getPassword())).thenReturn("encodedPassword");
@@ -61,9 +60,8 @@ class UserServiceImplTest {
 
         // Then: UserRepository의 save 메소드가 한 번 호출되어야 한다.
         verify(userRepository, times(1)).save(argThat(savedUser ->
-                savedUser.getUsername().equals(user.getUsername()) &&
+                savedUser.getEmail().equals(user.getEmail()) &&
                         savedUser.getPassword().equals("encodedPassword") &&
-                        savedUser.getEmail().equals(user.getEmail()) &&
                         savedUser.getPhoneNumber().equals(user.getPhoneNumber()) &&
                         savedUser.getAddress().equals(user.getAddress()) &&
                         savedUser.getUserRole().equals(user.getUserRole())
@@ -73,7 +71,7 @@ class UserServiceImplTest {
     @Test
     void 이미_존재하는_유저일_때_예외발생() {
         // Given: 이미 존재하는 사용자 이름이 있을 경우를 시뮬레이션
-        when(userRepository.existsByUsername(userJoinDTO.getUsername())).thenReturn(true);
+        when(userRepository.existsByEmail(userJoinDTO.getEmail())).thenReturn(true);
 
         // When & Then: IllegalArgumentException이 발생해야 한다.
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {


### PR DESCRIPTION
## Pull Request Template

## 🛰️ Issue Number
#32 [Feat] 로그아웃 필터 구현 및 검증 

## 🪐 작업 내용
1. 로그아웃 필터 구현 및 검증
2. 로그아웃 필터 삽입
3. 로그인 방식을 email 사용으로 변경, username 필드 폐기 
4. 로그인 방식 변경을 위한 기존 작성 코드들 수정 

## 📚 Reference
<<이메일 로그인>> 엑세스 토큰, 리프레시 토큰 각각 발급해서 쿠키랑 헤더에 넣어줌
![image](https://github.com/user-attachments/assets/f14054dd-8fce-45c9-97ad-3f357a2da28b)

<<로그아웃>> 로그아웃 시 기존에 클라이언트가 갖고 있던 쿠키(리프레시 토큰) 소멸 시킴
![image](https://github.com/user-attachments/assets/a1eecf43-a762-49d9-8e79-0612c898051d)

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## ✅ PR 포인트 & 궁금한 점
로직 오류 및 오타
