### PR TITLE
[Feat] reissue 로직 구현

### DIFF
--- a/src/main/java/com/example/tenpaws/domain/user/controller/ReissueController.java
+++ b/src/main/java/com/example/tenpaws/domain/user/controller/ReissueController.java
@@ -1,0 +1,102 @@
+package com.example.tenpaws.domain.user.controller;
+
+import com.example.tenpaws.global.entity.UserRole;
+import com.example.tenpaws.global.security.entity.RefreshEntity;
+import com.example.tenpaws.global.security.jwt.JwtUtil;
+import com.example.tenpaws.global.security.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReissueController {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
+            }
+        }
+
+        if (refresh == null) {
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        try {
+            if (jwtUtil.isExpired(refresh)) {
+                return new ResponseEntity<>("Refresh token expired", HttpStatus.BAD_REQUEST);
+            }
+        } catch (IllegalArgumentException | ExpiredJwtException e) {
+            return new ResponseEntity<>("Invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        String email = jwtUtil.getEmail(refresh);
+        UserRole userRole = jwtUtil.getRole(refresh);
+
+        String newAccessToken = jwtUtil.createJwt("access", email, userRole, 3_600_000L);
+        String newRefreshToken = jwtUtil.createJwt("refresh", email, userRole, 86_400_000L);
+
+        refreshRepository.deleteByRefresh(refresh);
+        addRefreshEntity(email, newRefreshToken, 86_400_000L);
+
+        response.setHeader("Authorization", "Bearer " + newAccessToken);
+        response.addCookie(createCookie("refresh", newRefreshToken));
+
+        return new ResponseEntity<>(Map.of(
+                "message", "Tokens reissued successfully",
+                "accessToken", "Bearer " + newAccessToken
+        ), HttpStatus.OK);
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    private void addRefreshEntity(String email, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setEmail(email);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+}

--- a/src/main/java/com/example/tenpaws/global/security/jwt/LoginFilter.java
+++ b/src/main/java/com/example/tenpaws/global/security/jwt/LoginFilter.java
@@ -22,7 +22,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
-    private static final long ACCESS_TOKEN_EXPIRATION = 600_000L; // 10분
+    private static final long ACCESS_TOKEN_EXPIRATION = 3_600_000L; // 1시간
     private static final long REFRESH_TOKEN_EXPIRATION = 86_400_000L; // 24시간
 
     private final AuthenticationManager authenticationManager;


### PR DESCRIPTION
## Pull Request Template

## 🛰️ Issue Number
#36 
## 🪐 작업 내용
reissue 로직 구현 : 
1. 효율적인 jwt 관리를 위하여 로그인 시간 만료 후 재접속 시 엑세스 토큰 뿐만 아니라 리프레시 토큰도 같이 재발급 하여 서비스 사용감을 증가 시킴
2. 엑세스 토큰의 만료 시간을 기존 10분에서 1시간으로 변경 

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## ✅ PR 포인트 & 궁금한 점

