### PR TITLE
[Feat] 관리자 생성 (임시)

### DIFF
--- a/src/main/java/com/example/tenpaws/domain/admin/entity/Admin.java
+++ b/src/main/java/com/example/tenpaws/domain/admin/entity/Admin.java
@@ -28,4 +28,11 @@ public class Admin {
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role", nullable = false)
     private UserRole userRole;
+
+    public Admin(String username, String password, String email, UserRole userRole) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.userRole = userRole;
+    }
 }

--- a/src/main/java/com/example/tenpaws/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/example/tenpaws/domain/admin/repository/AdminRepository.java
@@ -1,7 +1,9 @@
 package com.example.tenpaws.domain.admin.repository;
 
 import com.example.tenpaws.domain.admin.entity.Admin;
+import com.example.tenpaws.global.entity.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
+    int countByUserRole(UserRole userRole);
 }

--- a/src/main/java/com/example/tenpaws/global/initializer/AdminInitializer.java
+++ b/src/main/java/com/example/tenpaws/global/initializer/AdminInitializer.java
@@ -1,0 +1,34 @@
+package com.example.tenpaws.global.initializer;
+
+import com.example.tenpaws.domain.admin.entity.Admin;
+import com.example.tenpaws.domain.admin.repository.AdminRepository;
+import com.example.tenpaws.global.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AdminInitializer implements CommandLineRunner {
+
+    private final AdminRepository adminRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (adminRepository.countByUserRole(UserRole.ROLE_ADMIN) > 0) {
+            return;
+        }
+
+        List<Admin> admins = List.of(
+                new Admin("TENPAWS_ADMIN_1", bCryptPasswordEncoder.encode("tenpaws1"), "tenpaws1@tenpaws.com", UserRole.ROLE_ADMIN),
+                new Admin("TENPAWS_ADMIN_2", bCryptPasswordEncoder.encode("tenpaws2"), "tenpaws2@tenpaws.com", UserRole.ROLE_ADMIN),
+                new Admin("TENPAWS_ADMIN_3", bCryptPasswordEncoder.encode("tenpaws3"), "tenpaws3@tenpaws.com", UserRole.ROLE_ADMIN)
+        );
+
+        adminRepository.saveAll(admins);
+    }
+}


### PR DESCRIPTION
## Pull Request Template

## 🛰️ Issue Number
#65 
## 🪐 작업 내용
내일 수업 참여가 힘들 거 같아 혹시나 관리자가 필요한 경우를 대비해서 간단하게 구현 가능한 관리자 생성 로직을 만들었습니다. 필요에 따라 승인 후 머지 하셔서 사용해주시면 될 것 같습니다!!!

관리자의 경우, 일반 유저와 달리 회원 가입을 통해 role을 부여 받는다거나 하는 방법은 사용하지 않습니다. 
크게 3가지 방법이 존재한다고 하는데 

1. 직접 데이터베이스 내에서 sql을 통해 생성, 
2. commandlinerunner 인터페이스를 통해 서버가 기동 시 자동으로 생성,
3. api를 통해 유동적인 관리자 생성 
이 그 방법입니다

하지만 1번 방법은 너무 비효율적이라 특정 상황이 아니면 거의 사용되지 않고, 2번 방법은 때에 따라 다르며, 3번의 경우가 대규모 서비스에서 사용되는 방법이라 하는데 일단 저는 2번으로 만들었지만 최종적으로는 3번으로 업그레이드 해보려 합니다.

3줄 요약)
1. 관리자가 필요
2. 쉽게 만드는 법과 어렵게 만드는 법 존재
3. 당장 필요하면 일단 쉬운 버전인 이것을 사용, 그렇지 않다면 나중에 어려운 버전으로 업그레이드 도전 

이상입니다! 

## 📚 Reference
![image](https://github.com/user-attachments/assets/7336b976-eee8-4690-8ef5-82ac873c01f5)

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## ✅ PR 포인트 & 궁금한 점

