### PR TITLE
Feat/#108 chatroom delete alarm

### DIFF
--- a/src/main/java/com/example/tenpaws/domain/chat/chatroom/dto/ClosedChatRoomResponse.java
+++ b/src/main/java/com/example/tenpaws/domain/chat/chatroom/dto/ClosedChatRoomResponse.java
@@ -1,0 +1,11 @@
+package com.example.tenpaws.domain.chat.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClosedChatRoomResponse {
+    private Long chatRoomId;
+    private String message;
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#108 [Feat] 채팅방 삭제 시 알람 기능 추가

## 🪐 작업 내용
- 채팅방 삭제 시 응답할 알림 DTO 추가
- 채팅방 삭제 요청에 알림 전송 코드 추가

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## ✅ PR 포인트 & 궁금한 점
- 참가중이던 채팅방을 삭제할 때, 채팅 상대방이 그 채팅방에 입장해있지 않은 상태에서는 문제없는데, 만약 상대방이 채팅방에 입장해있는 상태라면 이미 없어진 채팅방id를 기반으로 채팅 전송을 시도하기 때문에 에러가 발생할 수 있음
- 따라서 채팅방 삭제 시 상대방에게 알림을 보내주고 클라이언트 쪽에서 만약 채팅방에 입장해있는 상태라면 자동으로 퇴장할 수 있게 해줘야 함

close #108 