### PR TITLE
Mod/#136 chatroom delete

### DIFF
--- a/src/main/java/com/example/tenpaws/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/example/tenpaws/domain/chat/chatroom/controller/ChatRoomController.java
@@ -68,12 +68,12 @@ public class ChatRoomController {
     public ResponseEntity<Map<String, String>> deleteChatRoom(@PathVariable("chatRoomId") Long chatRoomId, Authentication authentication) {
         ChatRoomResponse chatRoom = chatRoomService.getChatRoom(chatRoomId);
         String receiver = authentication.getName().equals(chatRoom.getUserEmail()) ? chatRoom.getOppositeEmail() : chatRoom.getUserEmail();
+        chatRoomService.delete(chatRoomId);
         messagingTemplate.convertAndSendToUser(
                 receiver,
                 "/queue/chatroom-close",
                 new ClosedChatRoomResponse(chatRoomId, "상대방이 채팅방을 나갔습니다.")
         );
-        chatRoomService.delete(chatRoomId);
         return ResponseEntity.ok(Map.of("message", "ChatRoom deleted"));
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#136 [Mod] 채팅방 삭제 로직 순서 조정

## 🪐 작업 내용
- 채팅방 삭제 로직 순서 조정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## ✅ PR 포인트 & 궁금한 점
- 채팅방 삭제 후 최신화된 채팅방 목록을 불러와 프론트에서 보여주는 과정에서 삭제되기 이전의 목록을 그대로 불러오는 현상 발생
- 여러가지 다 뜯어본 후, 알림 전송과 삭제 코드의 순서 때문으로 판단
- 채팅방 삭제 코드 한 줄만 순서를 조정해주니 해결

close #136 