### PR TITLE
[Feat] 블랙리스트 내용 개선 및 접근 경로 강화

### DIFF
--- a/src/main/java/com/example/tenpaws/global/advice/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/tenpaws/global/advice/OAuth2SuccessHandler.java
@@ -29,17 +29,25 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String email = oAuth2User.getEmail();
         String token = jwtUtil.createSocialJwt(userId, email);
 
-        // 로그인 성공 후, 발급된 토큰을 포함한 url 주소로 리다이렉팅
-        // 프론트 팀에서는 적절하게 해당 토큰을 저장하고, 유저가 서비스를 사용 가능하게 페이지 구축 또는 다른 주소로 연결
+        // 요청에서 기존 토큰을 가져와서 블랙리스트에서 삭제
+        String accessTokenFromRequest = getAccessTokenFromHeader(request);
+        if (accessTokenFromRequest != null && jwtUtil.isBlacklisted(accessTokenFromRequest)) {
+            jwtUtil.removeFromBlacklist(accessTokenFromRequest);
+        }
+
+        // 소셜 유저에 대한 새로운 토큰을 리다이렉트 URL에 포함하여 전송
         response.sendRedirect("http://localhost:3000/auth/oauth-response/" + token + "/3600");
     }
+
+    // 헤더에서 토큰을 추출하는 메소드
+    private String getAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7); // "Bearer " 부분을 제외한 토큰만 반환
+        }
+        return null;
+    }
 }
-
-//리디렉션 URL은 백엔드에서 제공하는 http://localhost:3000/auth/oauth-response/{token}/3600와 같은 URL로, token 부분은 백엔드에서 생성된 JWT 토큰이고 /3600은 만료 시간을 나타냅니다.
-//프론트엔드는 이 URL에서 토큰을 받아서 localStorage 또는 상태 관리(예: Redux, Context API)에 저장하여 이후의 요청에 사용합니다.
-//만료 시간(3600초)을 함께 보내는 경우, 토큰의 유효 기간을 추적하거나, 만료되었을 때 토큰 갱신을 처리할 수 있습니다.
-//프론트엔드는 이 URL을 통해 백엔드에서 받은 JWT 토큰을 활용하여 로그인 상태를 유지하고, 이후 보호된 리소스에 대한 요청을 인증된 사용자로 처리할 수 있습니다.
-
 
 
 

--- a/src/main/java/com/example/tenpaws/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/tenpaws/global/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -103,8 +104,28 @@ public class SecurityConfig {
         // 모든 기능 완성되면 그 때 엔드포인트 보고 접근 권한 수정!
         httpSecurity
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/**").permitAll()
-                        .anyRequest().permitAll());
+                        // 웹소켓 관련 설정
+                        .requestMatchers("/ws/**").permitAll()
+                        // GET 요청에 대한 permitAll 허용
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/announcements", "/api/v1/announcements/{announcementId}",
+                                "/api/v1/inquiries", "/api/v1/inquiries/{inquiryId}",
+                                "/api/v1/faqs", "/api/v1/faqs/top-level", "/api/v1/faqs/{parentId}",
+                                "/api/v1/features/check-email",
+                                "/api/v1/pets", "/api/v1/pets/{petId}",
+                                "/" // 홈 화면은 GET 요청만 허용
+                        ).permitAll()
+
+                        // POST 요청에 대한 permitAll 허용
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/v1/users/regular/join", "/api/v1/users/shelter/join",
+                                "/login", "/logout", "/api/v1/auth/oauth2/naver", "/api/v1/auth/oauth2/kakao"
+                        ).permitAll()
+
+                        // 나머지 요청에 대한 인증 필요
+                        .anyRequest().authenticated()
+                );
+
 
         httpSecurity
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshRepository), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/tenpaws/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/example/tenpaws/global/security/jwt/JwtFilter.java
@@ -20,12 +20,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Set;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -40,9 +42,48 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return path.equals("/login") || path.equals("/") || path.equals("/logout")
-                || path.equals("/api/v1/users/regular/join") || path.equals("/api/v1/users/shelter/join")
-                || path.equals("/api/v1/auth/oauth2/kakao") || path.equals("/api/v1/auth/oauth2/naver");
+        String method = request.getMethod();
+
+        // GET 메서드로 허용된 경로
+        Set<String> getAllowedPaths = Set.of(
+                "/api/v1/announcements",
+                "/api/v1/announcements/{announcementId}",
+                "/api/v1/inquiries",
+                "/api/v1/inquiries/{inquiryId}",
+                "/api/v1/faqs",
+                "/api/v1/faqs/top-level",
+                "/api/v1/faqs/{parentId}",
+                "/api/v1/features/check-email",
+                "/api/v1/pets",
+                "/api/v1/pets/{petId}",
+                "/"
+        );
+
+        // POST 메서드로 허용된 경로
+        Set<String> postAllowedPaths = Set.of(
+                "/login",
+                "/logout",
+                "/api/v1/users/regular/join",
+                "/api/v1/users/shelter/join",
+                "/api/v1/auth/oauth2/naver",
+                "/api/v1/auth/oauth2/kakao"
+        );
+
+        // 경로와 메서드 조건 확인
+        if (method.equals(HttpMethod.GET.name()) && getAllowedPaths.contains(path)) {
+            return true;
+        }
+
+        if (method.equals(HttpMethod.POST.name()) && postAllowedPaths.contains(path)) {
+            return true;
+        }
+
+        // /ws/** 패턴 허용
+        if (path.startsWith("/ws/")) {
+            return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/com/example/tenpaws/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/tenpaws/global/security/jwt/JwtUtil.java
@@ -110,4 +110,8 @@ public class JwtUtil {
             return false; // 예외 발생한 경우, 토큰이 유효하지 않음 false
         }
     }
+
+    public void removeExpiredTokensFromBlacklist() {
+        blacklistedTokens.removeIf(this::isExpired);
+    }
 }

--- a/src/main/java/com/example/tenpaws/global/security/jwt/LoginFilter.java
+++ b/src/main/java/com/example/tenpaws/global/security/jwt/LoginFilter.java
@@ -50,7 +50,15 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String accessTokenFromRequest = getAccessTokenFromHeader(request);
 
-        if (accessTokenFromRequest != null && jwtUtil.isValidAccessToken(accessTokenFromRequest)) {
+        if (accessTokenFromRequest != null && jwtUtil.isBlacklisted(accessTokenFromRequest)) {
+            jwtUtil.removeFromBlacklist(accessTokenFromRequest);
+
+            String newAccessToken = jwtUtil.createJwt("access", email, userRole, ACCESS_TOKEN_EXPIRATION);
+            String newRefreshToken = jwtUtil.createJwt("refresh", email, userRole, REFRESH_TOKEN_EXPIRATION);
+
+            response.setHeader("Authorization", "Bearer " + newAccessToken);
+            response.addCookie(createCookie("refresh", newRefreshToken));
+            response.setStatus(HttpStatus.OK.value());
             return;
         }
 

--- a/src/main/java/com/example/tenpaws/global/security/service/JwtBlacklistService.java
+++ b/src/main/java/com/example/tenpaws/global/security/service/JwtBlacklistService.java
@@ -1,0 +1,18 @@
+package com.example.tenpaws.global.security.service;
+
+import com.example.tenpaws.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtBlacklistService {
+
+    private final JwtUtil jwtUtil;
+
+    @Scheduled(cron = "0 0/5 * * * ?") // 엑세스 토큰은 1시간, 5분마다 블랙리스트 자동 삭제
+    public void cleanExpiredTokens() {
+        jwtUtil.removeExpiredTokensFromBlacklist();
+    }
+}


### PR DESCRIPTION
## Pull Request Template

## 🛰️ Issue Number
#135 
## 🪐 작업 내용
1. 블랙리스트 동작 기능 강화
1-1 로그인 시 서버로 부터 클라이언트에게 리프레시 토큰과 엑세스 토큰이 발급
1-2 로그아웃 시 리프레시 토큰은 자동 소멸되지만 엑세스 토큰은 만료되지 않은 채 그대로 남아있어 재로그인 시 사용 가능한 문제가 발생한다는 것을 인지
1-3 로그아웃 시 엑세스 토큰을 블랙리스트에 넣어 관리하는 방법을 선택
1-4 다음 로그인 시 엑세스 토큰이 살아있다면 블랙리스트를 조회하여 존재할 시, 유효하지 않은 토큰으로 판정하고 새로운 토큰을 발급, 토큰이 살아있지 않다면 기존의 로직 그대로 재발급이 성공
1-5 소셜 로그인 유저의 경우에도 핸들러에 블랙리스트 자동 처리 로직을 담아놔서 블랙리스트 토큰을 자동 소각하게 만듦
1-6 어떤 경우에도 없어지지 않는 토큰의 경우 저장소가 비대해질 가능성이 있어 스케줄러를 통해 5분 마다 자동 소각하도록 진행. 엑세스 토큰은 1시간 짜리라 5분이면 적당하다 생각했는데 추후 수정이 필요 할 수도 있을 것 같음

접근 경로 수정
1. 모든 permitAll 경로에 대해 method를 이용하여 경로를 설정
2. 나머지 경로에 대해서는 인증 받은 사용자만 접근이 가능
3. 웹소켓에 대한 경로는 모두 허용으로 설정 

## 📚 Reference
중간에 응답 없음이 뜨더니 작성했던 코드와 클래스들이 다 날아간 이슈와 테스트 해보느라 많이 늦어져서 죄송합니다 ㅠ
로직만 추가한 것이다 보니 따로 테스트 코드는 없어 이 부분은 문제 없을 것 같습니다

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## ✅ PR 포인트 & 궁금한 점

